### PR TITLE
Example services should add their situation context to the Arete Control Plane on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Added
 - [#52](https://github.com/project-arete/sdk/issues/52) (Rust) Implement a Light example service
+- [#26](https://github.com/project-arete/sdk/issues/26) (NodeJS) Example services should add their situation context to the Arete Control Plane on startup
 
 ### Changed
 - [#60](https://github.com/project-arete/sdk/issues/60) (Rust) Rename Connection → Client for consistency with other language SDKs

--- a/nodejs/examples/01_the_switch_and_the_light/light.js
+++ b/nodejs/examples/01_the_switch_and_the_light/light.js
@@ -2,6 +2,8 @@ import { Gpio } from 'onoff';
 import { Client } from '../../index.js';
 
 const APPNAME = 'arete-sdk-01-light';
+const CONTEXT_ID = 'uRLoYsXEY7nsbs9fRdjM8A';
+const CONTEXT_NAME = 'Building 23, Office 41-B';
 const GPIO23 = 535;
 const NODE_ID = 'onqXVczGoymQkFc3UN6qcM';
 const DESIRED_STATE_KEY =
@@ -23,6 +25,8 @@ console.log('Connected to Arete control plane');
 await client.addSystem();
 await client.addNode(NODE_ID, APPNAME, false);
 console.log(`Registered as node ${NODE_ID} on Arete control plane`);
+await client.addContext(NODE_ID, CONTEXT_ID, CONTEXT_NAME);
+console.log(`Registered context ${CONTEXT_ID} for node ${NODE_ID} on Arete control plane`);
 
 // Detect initial desired state, plus future changes to desired state, and try to actualize it
 client.on('update', (event) => {

--- a/nodejs/examples/01_the_switch_and_the_light/switch.js
+++ b/nodejs/examples/01_the_switch_and_the_light/switch.js
@@ -2,6 +2,8 @@ import { Gpio } from 'onoff';
 import { Client } from '../../index.js';
 
 const APPNAME = 'arete-sdk-01-switch';
+const CONTEXT_ID = 'uRLoYsXEY7nsbs9fRdjM8A';
+const CONTEXT_NAME = 'Building 23, Office 41-B';
 const GPIO04 = 516;
 const NODE_ID = 'ozr9fZbU8i7hMdjEjuTS2o';
 const DESIRED_STATE_KEY =
@@ -23,6 +25,8 @@ console.log('Connected to Arete control plane');
 await client.addSystem();
 await client.addNode(NODE_ID, APPNAME, false);
 console.log(`Registered as node ${NODE_ID} on Arete control plane`);
+await client.addContext(NODE_ID, CONTEXT_ID, CONTEXT_NAME);
+console.log(`Registered context ${CONTEXT_ID} for node ${NODE_ID} on Arete control plane`);
 
 // Read initial switch state, and sync it with Arete
 let state = pin.readSync();

--- a/nodejs/index.js
+++ b/nodejs/index.js
@@ -346,6 +346,21 @@ export class Client extends Emitter {
   }
 
   /**
+   * Add a context.
+   * @method
+   * @param {string} nodeId The globally unique node id.
+   * @param {string} id The globally unique context id.
+   * @param {string} name The human-readable context name.
+   * @returns {Promise} Returns a promise.
+   * @fulfil {string} - The response from the host.
+   * @reject {Error} - The request failed.
+   */
+  addContext(nodeId, id, name, upstream) {
+    const args = [this.#systemID, nodeId, id, name];
+    return this.#send('json', 'contexts', ...args);
+  }
+
+  /**
    * Add a node.
    * @method
    * @param {string} id The globally unique node id.
@@ -356,7 +371,7 @@ export class Client extends Emitter {
    * @reject {Error} - The request failed.
    */
   addNode(id, name, upstream) {
-    const args = [id, name, upstream, null];
+    const args = [this.#systemID, id, name, upstream, null];
     return this.#send('json', 'nodes', ...args);
   }
 

--- a/python/examples/01_the_switch_and_the_light/light.py
+++ b/python/examples/01_the_switch_and_the_light/light.py
@@ -8,6 +8,8 @@ sys.path.append('../../src')
 from client import Client
 
 APPNAME = "arete-sdk-01-light"
+CONTEXT_ID = "uRLoYsXEY7nsbs9fRdjM8A"
+CONTEXT_NAME = "Building 23, Office 41-B"
 GPIO23 = 23
 NODE_ID = 'onqXVczGoymQkFc3UN6qcM'
 
@@ -23,10 +25,12 @@ client = Client.connect('wss://dashboard.test.cns.dev:443', ssl=ssl_context)
 client.wait_for_open()
 sys.stderr.write('Connected to Arete control plane\n')
 
-# Register this node with the control plane
+# Register this node and its context with the control plane
 client.add_system()
 client.add_node(NODE_ID, APPNAME)
 sys.stderr.write(f'Registered as node {NODE_ID} on Arete control plane\n')
+client.add_context(NODE_ID, CONTEXT_ID, CONTEXT_NAME)
+sys.stderr.write(f'Registered context {CONTEXT_ID} for node {NODE_ID} on Arete control plane\n')
 
 # Detect initial desired state, plus future changes to desired state, and try to actualize it
 # TODO(https://github.com/project-arete/sdk/issues/57)

--- a/python/examples/01_the_switch_and_the_light/switch.py
+++ b/python/examples/01_the_switch_and_the_light/switch.py
@@ -10,6 +10,8 @@ sys.path.append('../../src')
 from client import Client
 
 APPNAME = "arete-sdk-01-switch"
+CONTEXT_ID = "uRLoYsXEY7nsbs9fRdjM8A"
+CONTEXT_NAME = "Building 23, Office 41-B"
 GPIO04 = 4
 NODE_ID = "ozr9fZbU8i7hMdjEjuTS2o"
 DESIRED_STATE_KEY = 'cns/network/nodes/sri4FZUq2V7S4ik2PrG4pj/contexts/kMqdHs8ZcskdkCvf1VpfSZ/provider/padi.button/connections/geizaJngWyA1AL3Nhn5dzD/properties/sState'
@@ -26,10 +28,12 @@ client = Client.connect('wss://dashboard.test.cns.dev:443', ssl=ssl_context)
 client.wait_for_open()
 sys.stderr.write('Connected to Arete control plane\n')
 
-# Register this node with the control plane
+# Register this node and its context with the control plane
 client.add_system()
 client.add_node(NODE_ID, APPNAME, False)
 sys.stderr.write(f'Registered as node {NODE_ID} on Arete control plane\n')
+client.add_context(NODE_ID, CONTEXT_ID, CONTEXT_NAME)
+sys.stderr.write(f'Registered context {CONTEXT_ID} for node {NODE_ID} on Arete control plane\n')
 
 # Read initial switch state, and sync it with Arete
 state = GPIO.input(GPIO04) == 0

--- a/python/src/client.py
+++ b/python/src/client.py
@@ -26,8 +26,12 @@ class Client:
 
         return client
 
+    def add_context(self, node_id, id, name):
+        args = [self.system_id, node_id, id, name]
+        return self.send('json', 'contexts', args)
+
     def add_node(self, id, name, upstream=False, token=None):
-        args = [id, name, upstream]
+        args = [self.system_id, id, name, upstream]
         return self.send('json', 'nodes', args)
 
     def add_system(self, id=None, name=None):

--- a/rust/examples/01_the_switch_and_the_light/light.rs
+++ b/rust/examples/01_the_switch_and_the_light/light.rs
@@ -34,8 +34,9 @@ pub fn main() {
     // Register this node with the control plane
     client.add_system().unwrap();
     client.add_node(NODE_ID, APPNAME, false, None).unwrap();
-    client.add_context(NODE_ID, CONTEXT_ID, CONTEXT_NAME).unwrap();
     eprintln!("Registered as node {NODE_ID} on Arete control plane");
+    client.add_context(NODE_ID, CONTEXT_ID, CONTEXT_NAME).unwrap();
+    eprintln!("Registered context {CONTEXT_ID} with node {NODE_ID} on Arete control plane");
 
     // Detect future changes in desired state, and try to actualize it
     // TODO(https://github.com/project-arete/sdk/issues/56)

--- a/rust/examples/01_the_switch_and_the_light/light.rs
+++ b/rust/examples/01_the_switch_and_the_light/light.rs
@@ -31,12 +31,12 @@ pub fn main() {
         .unwrap();
     eprintln!("Connected to Arete control plane");
 
-    // Register this node with the control plane
+    // Register this node and its context with the control plane
     client.add_system().unwrap();
     client.add_node(NODE_ID, APPNAME, false, None).unwrap();
     eprintln!("Registered as node {NODE_ID} on Arete control plane");
     client.add_context(NODE_ID, CONTEXT_ID, CONTEXT_NAME).unwrap();
-    eprintln!("Registered context {CONTEXT_ID} with node {NODE_ID} on Arete control plane");
+    eprintln!("Registered context {CONTEXT_ID} for node {NODE_ID} on Arete control plane");
 
     // Detect future changes in desired state, and try to actualize it
     // TODO(https://github.com/project-arete/sdk/issues/56)

--- a/rust/examples/01_the_switch_and_the_light/light.rs
+++ b/rust/examples/01_the_switch_and_the_light/light.rs
@@ -1,6 +1,8 @@
 #![allow(unused)]
 
 const APPNAME: &str = "arete-sdk-01-light";
+const CONTEXT_ID: &str = "uRLoYsXEY7nsbs9fRdjM8A";
+const CONTEXT_NAME: &str = "Building 23, Office 41-B";
 const DEFAULT_TIMEOUT_MILLIS: u64 = 500;
 const GPIO23: u32 = 23;
 const NODE_ID: &str = "onqXVczGoymQkFc3UN6qcM";
@@ -32,6 +34,7 @@ pub fn main() {
     // Register this node with the control plane
     client.add_system().unwrap();
     client.add_node(NODE_ID, APPNAME, false, None).unwrap();
+    client.add_context(NODE_ID, CONTEXT_ID, CONTEXT_NAME).unwrap();
     eprintln!("Registered as node {NODE_ID} on Arete control plane");
 
     // Detect future changes in desired state, and try to actualize it

--- a/rust/examples/01_the_switch_and_the_light/switch.rs
+++ b/rust/examples/01_the_switch_and_the_light/switch.rs
@@ -30,12 +30,12 @@ pub fn main() {
         .unwrap();
     eprintln!("Connected to Arete control plane");
 
-    // Register this node with the control plane
+    // Register this node and its context with the control plane
     client.add_system().unwrap();
     client.add_node(NODE_ID, APPNAME, false, None).unwrap();
     eprintln!("Registered as node {NODE_ID} on Arete control plane");
     client.add_context(NODE_ID, CONTEXT_ID, CONTEXT_NAME).unwrap();
-    eprintln!("Registered context {CONTEXT_ID} with node {NODE_ID} on Arete control plane");
+    eprintln!("Registered context {CONTEXT_ID} for node {NODE_ID} on Arete control plane");
 
     // Read initial switch state, and sync it with Arete
     let line_request_flags = LineRequestFlags::INPUT | LineRequestFlags::ACTIVE_LOW;

--- a/rust/examples/01_the_switch_and_the_light/switch.rs
+++ b/rust/examples/01_the_switch_and_the_light/switch.rs
@@ -33,8 +33,9 @@ pub fn main() {
     // Register this node with the control plane
     client.add_system().unwrap();
     client.add_node(NODE_ID, APPNAME, false, None).unwrap();
-    client.add_context(NODE_ID, CONTEXT_ID, CONTEXT_NAME).unwrap();
     eprintln!("Registered as node {NODE_ID} on Arete control plane");
+    client.add_context(NODE_ID, CONTEXT_ID, CONTEXT_NAME).unwrap();
+    eprintln!("Registered context {CONTEXT_ID} with node {NODE_ID} on Arete control plane");
 
     // Read initial switch state, and sync it with Arete
     let line_request_flags = LineRequestFlags::INPUT | LineRequestFlags::ACTIVE_LOW;

--- a/rust/examples/01_the_switch_and_the_light/switch.rs
+++ b/rust/examples/01_the_switch_and_the_light/switch.rs
@@ -1,6 +1,8 @@
 #![allow(unused)]
 
 const APPNAME: &str = "arete-sdk-01-switch";
+const CONTEXT_ID: &str = "uRLoYsXEY7nsbs9fRdjM8A";
+const CONTEXT_NAME: &str = "Building 23, Office 41-B";
 const DEFAULT_TIMEOUT_MILLIS: u64 = 500;
 const GPIO04: u32 = 4;
 const NODE_ID: &str = "ozr9fZbU8i7hMdjEjuTS2o";
@@ -31,6 +33,7 @@ pub fn main() {
     // Register this node with the control plane
     client.add_system().unwrap();
     client.add_node(NODE_ID, APPNAME, false, None).unwrap();
+    client.add_context(NODE_ID, CONTEXT_ID, CONTEXT_NAME).unwrap();
     eprintln!("Registered as node {NODE_ID} on Arete control plane");
 
     // Read initial switch state, and sync it with Arete

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -131,6 +131,19 @@ impl Client {
         }
     }
 
+    pub fn add_context(&mut self, node_id: &str, id: &str, name: &str) -> Result<(), Error> {
+        let system_id = system::get_system_id()?;
+        let args = vec![
+            system_id.to_string(),
+            node_id.to_string(),
+            id.to_string(),
+            name.to_string(),
+        ];
+        let transaction = self.send(Format::Json, "contexts", &args)?;
+        let _response = self.wait_for_response(transaction, Duration::from_secs(DEFAULT_TIMEOUT_SECS))?;
+        Ok(())
+    }
+
     pub fn add_node(&mut self, id: &str, name: &str, upstream: bool, token: Option<String>) -> Result<(), Error> {
         let system_id = system::get_system_id()?;
         let upstream_arg = if upstream { "yes".to_string() } else { "no".to_string() };


### PR DESCRIPTION
Closes #26.