### PR TITLE
De-clutter the examples

### DIFF
--- a/nodejs/examples/01_the_switch_and_the_light/light.js
+++ b/nodejs/examples/01_the_switch_and_the_light/light.js
@@ -23,20 +23,13 @@ let client = new Client({
 await client.waitForOpen(5000);
 console.log('Connected to Arete control plane');
 
-// Register this node and its context with the control plane
+// Register with the control plane
 let system = await client.system();
 let node = await system.node(NODE_ID, NODE_NAME, false);
-console.log(`Registered as node ${NODE_ID}`);
 let context = await node.context(CONTEXT_ID, CONTEXT_NAME);
-console.log(`Registered context ${CONTEXT_ID} for node ${NODE_ID}`);
-
-// Register as a consumer of state for the "padi.light" profile
-let consumer = await context.consumer(PADI_LIGHT_PROFILE);
-console.log(
-  `Registered as a consumer of state for ${PADI_LIGHT_PROFILE} profile for context ${CONTEXT_ID}`,
-);
 
 // Detect initial desired state, plus future changes to desired state, and try to actualize it
+let consumer = await context.consumer(PADI_LIGHT_PROFILE);
 consumer.watch((event) => {
   if (event.property == 'sOut') {
     const desiredState = event.value == '1';

--- a/nodejs/examples/01_the_switch_and_the_light/switch.js
+++ b/nodejs/examples/01_the_switch_and_the_light/switch.js
@@ -23,21 +23,14 @@ let client = new Client({
 await client.waitForOpen(5000);
 console.log('Connected to Arete control plane');
 
-// Register this node and its context with the control plane
+// Register with the control plane
 let system = await client.system();
 let node = await system.node(NODE_ID, NODE_NAME, false);
-console.log(`Registered as node ${NODE_ID}`);
 let context = await node.context(CONTEXT_ID, CONTEXT_NAME);
-console.log(`Registered context ${CONTEXT_ID} for node ${NODE_ID}`);
-
-// Register as a provider of state for the "padi.light" profile
-let provider = await context.provider(PADI_LIGHT_PROFILE);
-console.log(
-  `Registered as a provider of state for ${PADI_LIGHT_PROFILE} profile for context ${CONTEXT_ID}`,
-);
 
 // Read initial switch state, and sync it with Arete
 let state = pin.readSync();
+let provider = await context.provider(PADI_LIGHT_PROFILE);
 provider.put('sOut', state ? '1' : '0');
 console.log('Switch is initially', state ? 'ON' : 'OFF');
 

--- a/python/examples/01_the_switch_and_the_light/light.py
+++ b/python/examples/01_the_switch_and_the_light/light.py
@@ -35,7 +35,6 @@ node = system.node(NODE_ID, NODE_NAME)
 context = node.context(CONTEXT_ID, CONTEXT_NAME)
 
 # Detect initial desired state, plus future changes to desired state, and try to actualize it
-consumer = context.consumer(PADI_LIGHT_PROFILE)
 def detect_change(event):
     if event['property'] == 'sOut':
         desired_state = event['value'] == '1'
@@ -43,6 +42,7 @@ def detect_change(event):
         sys.stderr.write('Light is now {}\n'.format('ON' if desired_state else 'OFF'))
 
 
+consumer = context.consumer(PADI_LIGHT_PROFILE)
 consumer.watch(detect_change)
 
 

--- a/python/examples/01_the_switch_and_the_light/light.py
+++ b/python/examples/01_the_switch_and_the_light/light.py
@@ -34,6 +34,7 @@ system = client.system()
 node = system.node(NODE_ID, NODE_NAME)
 context = node.context(CONTEXT_ID, CONTEXT_NAME)
 
+
 # Detect initial desired state, plus future changes to desired state, and try to actualize it
 def detect_change(event):
     if event['property'] == 'sOut':

--- a/python/examples/01_the_switch_and_the_light/light.py
+++ b/python/examples/01_the_switch_and_the_light/light.py
@@ -29,19 +29,13 @@ client = Client.connect('wss://dashboard.test.cns.dev:443', ssl=ssl_context)
 client.wait_for_open()
 sys.stderr.write('Connected to Arete control plane\n')
 
-# Register this node and its context with the control plane
+# Register with the control plane
 system = client.system()
 node = system.node(NODE_ID, NODE_NAME)
-sys.stderr.write(f'Registered as node {NODE_ID}\n')
 context = node.context(CONTEXT_ID, CONTEXT_NAME)
-sys.stderr.write(f'Registered context {CONTEXT_ID} for node {NODE_ID}\n')
-
-# Register as a consumer of state for the "padi.light" profile
-consumer = context.consumer(PADI_LIGHT_PROFILE)
-sys.stderr.write(f'Registered as consumer of state for {PADI_LIGHT_PROFILE} profile for context {CONTEXT_ID}\n')
-
 
 # Detect initial desired state, plus future changes to desired state, and try to actualize it
+consumer = context.consumer(PADI_LIGHT_PROFILE)
 def detect_change(event):
     if event['property'] == 'sOut':
         desired_state = event['value'] == '1'

--- a/python/examples/01_the_switch_and_the_light/switch.py
+++ b/python/examples/01_the_switch_and_the_light/switch.py
@@ -31,19 +31,14 @@ client = Client.connect('wss://dashboard.test.cns.dev:443', ssl=ssl_context)
 client.wait_for_open()
 sys.stderr.write('Connected to Arete control plane\n')
 
-# Register this node and its context with the control plane
+# Register with the control plane
 system = client.system()
 node = system.node(NODE_ID, NODE_NAME, False)
-sys.stderr.write(f'Registered as node {NODE_ID}\n')
 context = node.context(CONTEXT_ID, CONTEXT_NAME)
-sys.stderr.write(f'Registered context {CONTEXT_ID} for node {NODE_ID}\n')
-
-# Register as provider of state for the "padi.light" profile
-provider = context.provider(PADI_LIGHT_PROFILE)
-sys.stderr.write(f'Registered as provider of state for {PADI_LIGHT_PROFILE} profile for context {CONTEXT_ID}\n')
 
 # Read initial switch state, and sync it with Arete
 state = GPIO.input(GPIO04) == 0
+provider = context.provider(PADI_LIGHT_PROFILE)
 provider.put("sOut", '1' if state else '0')
 sys.stderr.write('Switch is initially {}\n'.format('ON' if state else 'OFF'))
 

--- a/rust/examples/01_the_switch_and_the_light/light.rs
+++ b/rust/examples/01_the_switch_and_the_light/light.rs
@@ -33,20 +33,14 @@ pub fn main() {
     client
         .wait_for_open(Duration::from_millis(DEFAULT_TIMEOUT_MILLIS))
         .unwrap();
-    eprintln!("Connected to Arete control plane");
 
-    // Register this node and its context with the control plane
+    // Register with the control plane
     let system = client.system().unwrap();
     let node = system.node(NODE_ID, NODE_NAME, false, None).unwrap();
-    eprintln!("Registered as node {NODE_ID}");
     let context = node.context(CONTEXT_ID, CONTEXT_NAME).unwrap();
-    eprintln!("Registered context {CONTEXT_ID} for node {NODE_ID}");
-
-    // Register as a consumer of state for the "padi.light" profile
-    let consumer = context.consumer(PADI_LIGHT_PROFILE).unwrap();
-    eprintln!("Registered as consumer of state for {PADI_LIGHT_PROFILE} profile for context {CONTEXT_ID}");
 
     // Detect current desired state, plus future changes to it, and try to actualize it
+    let consumer = context.consumer(PADI_LIGHT_PROFILE).unwrap();
     std::thread::spawn(move || {
         let updates_rx = consumer.watch().unwrap();
         loop {

--- a/rust/examples/01_the_switch_and_the_light/switch.rs
+++ b/rust/examples/01_the_switch_and_the_light/switch.rs
@@ -31,18 +31,11 @@ pub fn main() {
     client
         .wait_for_open(Duration::from_millis(DEFAULT_TIMEOUT_MILLIS))
         .unwrap();
-    eprintln!("Connected to Arete control plane");
 
-    // Register this node and its context with the control plane
+    // Register with the control plane
     let system = client.system().unwrap();
     let node = system.node(NODE_ID, NODE_NAME, false, None).unwrap();
-    eprintln!("Registered as node {NODE_ID}");
     let context = node.context(CONTEXT_ID, CONTEXT_NAME).unwrap();
-    eprintln!("Registered context {CONTEXT_ID} for node {NODE_ID}");
-
-    // Register as a provider of state for the "padi.light" profile
-    let provider = context.provider(PADI_LIGHT_PROFILE).unwrap();
-    eprintln!("Registered as provider of state for {PADI_LIGHT_PROFILE} profile for context {CONTEXT_ID}");
 
     // Read initial switch state, and sync it with Arete
     let line_request_flags = LineRequestFlags::INPUT | LineRequestFlags::ACTIVE_LOW;
@@ -52,6 +45,7 @@ pub fn main() {
         .get_value()
         .unwrap()
         > 0;
+    let provider = context.provider(PADI_LIGHT_PROFILE).unwrap();
     provider.put("sOut", if state { "1" } else { "0" }).unwrap();
     eprintln!("Switch is initially {}", if state { "ON" } else { "OFF" });
 


### PR DESCRIPTION
Remove logging that is cluttering the examples. Removes 36 lines to simplify.