### PR TITLE
Fix: NodeJS examples should require a built+installed package dependency and not use a relative path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Changed
 - [#96](https://github.com/project-arete/sdk/issues/96) (Rust) Upgrade Rust 1.88.0 → 1.90.0
 
+### Fixed
+- [#95](https://github.com/project-arete/sdk/issues/95) (NodeJS) Examples should require a built+installed package dependency and not use a relative path
+
 ## [0.1.6] - 2025-09-26
 ### Added
 - [#90](https://github.com/project-arete/sdk/issues/90) Consumer and Provider classes/structs both require get, put, and watch capabilities

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -2,10 +2,16 @@
 
 ## Installing
 
-Add to your NodeJS project with:
+Add to your NodeJS project using the latest release published to NPM with:
 
 ```shell
 $ npm install --save arete-sdk
+```
+
+Or install the local Git workspace with:
+
+```shell
+$ npm install
 ```
 
 ## Using

--- a/nodejs/examples/01_the_switch_and_the_light/package.json
+++ b/nodejs/examples/01_the_switch_and_the_light/package.json
@@ -7,7 +7,7 @@
   "private": false,
   "type": "module",
   "dependencies": {
-    "arete-sdk": "file:../..",
+    "arete-sdk": "^0.1.6",
     "onoff": "^6.0.3"
   }
 }

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "arete-sdk",
-  "version": "0.1.2",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "arete-sdk",
-      "version": "0.1.2",
+      "version": "0.1.6",
       "license": "(MIT or Apache-2.0)",
       "dependencies": {
         "uuidv5": "^1.0.0",


### PR DESCRIPTION
Fixes #95.